### PR TITLE
NextPageUrl header is actually NextPageUri

### DIFF
--- a/office-365-management-api/office-365-management-activity-api-reference.md
+++ b/office-365-management-api/office-365-management-activity-api-reference.md
@@ -300,11 +300,11 @@ When listing available content for a time range, the number of results returned 
 ```json
 HTTP/1.1 200 OK
 Content-Type: application/json; charset=utf-8
-NextPageUrl: https://manage.office.com/api/v1/{tenant_id}/activity/feed/subscriptions/content?contentType=Audit.SharePoint&amp;startTime=2015-10-01&amp;endTime=2015-10-02&amp;nextPage=2015101900R022885001761
+NextPageUri: https://manage.office.com/api/v1/{tenant_id}/activity/feed/subscriptions/content?contentType=Audit.SharePoint&amp;startTime=2015-10-01&amp;endTime=2015-10-02&amp;nextPage=2015101900R022885001761
 
 ```
 
-To list all available content for a specified time range, you might need to retrieve multiple pages until a response without the **NextPageUrl** header is received.
+To list all available content for a specified time range, you might need to retrieve multiple pages until a response without the **NextPageUri** header is received.
 
 
 ## Receiving notifications


### PR DESCRIPTION
When testing the pagination, I realized it is actually a **NextPageUri** header that is sent, and not **NextPageUrl**