### PR TITLE
RecordType not updated

### DIFF
--- a/office-365-management-api/office-365-management-activity-api-schema.md
+++ b/office-365-management-api/office-365-management-activity-api-schema.md
@@ -92,7 +92,7 @@ This article provides details on the Common schema as well as each of the produc
 |25|MicrosoftTeams|Events from Microsoft Teams.|
 |26|MicrosoftTeamsAddOns|Events from Microsoft Teams Add-ons.|
 |27|MicrosoftTeamsSettingsOperation|Settings changes from Microsoft Teams.|
-
+MISSING RECORDTYPE LIKE 21,22,23,29,30,32,35,36
 
 ### Enum: User Type - Type: Edm.Int32
 


### PR DESCRIPTION
Hi, I've not applied any change because I don't know what to change. Support asked me to contribute in this way...
Here is the list of missing RecordType in documentation that are sent by Management API:
- 21,22,23,29,30,32,35,36

All schemas related to these are missing too:Project, Stream, CRM and more. 

Could you please update docs accordingly?

Thanks,
Ivan