### PR TITLE
Update office-365-service-communications-api-reference.md

### DIFF
--- a/office-365-management-api/office-365-service-communications-api-reference.md
+++ b/office-365-management-api/office-365-service-communications-api-reference.md
@@ -138,7 +138,8 @@ Authorization: Bearer {AAD_Bearer_JWT_Token}
 
 Returns the status of the service over the previous 24 hours.
 
-> [!NOTE] Please note the service response will contain the status as of 24 hours from when the request was made. The StatusDate or StatusTime value returned will be exactly 24 hours in the past. 
+> [!NOTE] 
+> Please note the service response will contain the status as of 24 hours from when the request was made. The StatusDate or StatusTime value returned will be exactly 24 hours in the past. 
 
 ||Service|Description|
 |:-----|:-----|:-----|

--- a/office-365-management-api/office-365-service-communications-api-reference.md
+++ b/office-365-management-api/office-365-service-communications-api-reference.md
@@ -1,6 +1,6 @@
 ---
-ms.TocTitle: Office 365 Service Communications API reference (preview)
-title: Office 365 Service Communications API reference (preview)
+ms.TocTitle: Office 365 Service Communications API reference (Preview)
+title: Office 365 Service Communications API reference (Preview)
 description: Use this API to access the following data - Get Services, Get Current Status, Get Historical Status, and Get Messages.
 ms.ContentId: d0b9341a-b205-5442-1c20-8fb56407351d
 ms.topic: reference (API)
@@ -8,7 +8,7 @@ ms.date:
 localization_priority: Priority
 ---
 
-# Office 365 Service Communications API reference (preview)
+# Office 365 Service Communications API reference (Preview)
 
 > [!NOTE] 
 > This documentation covers features that are currently in preview.

--- a/office-365-management-api/office-365-service-communications-api-reference.md
+++ b/office-365-management-api/office-365-service-communications-api-reference.md
@@ -138,6 +138,8 @@ Authorization: Bearer {AAD_Bearer_JWT_Token}
 
 Returns the status of the service over the previous 24 hours.
 
+> [!NOTE] Please note the service response will contain the status as of 24 hours from when the request was made. The StatusDate or StatusTime value returned will be exactly 24 hours in the past. 
+
 ||Service|Description|
 |:-----|:-----|:-----|
 |**Path**| `/CurrentStatus`||

--- a/office-365-management-api/office-365-service-communications-api-reference.md
+++ b/office-365-management-api/office-365-service-communications-api-reference.md
@@ -139,7 +139,7 @@ Authorization: Bearer {AAD_Bearer_JWT_Token}
 Returns the status of the service over the previous 24 hours.
 
 > [!NOTE] 
-> Please note the service response will contain the status as of 24 hours from when the request was made. The StatusDate or StatusTime value returned will be exactly 24 hours in the past. 
+> The service response will contain the status as of 24 hours from when the request was made. The StatusDate or StatusTime value returned will be exactly 24 hours in the past. 
 
 ||Service|Description|
 |:-----|:-----|:-----|


### PR DESCRIPTION
Adding information to explain why StatusDate or StatusTime is 24 hours in the past from when the request was made.