### PR TITLE
Add a note to the audit log enablement

### DIFF
--- a/office-365-management-api/troubleshooting-the-office-365-management-activity-api.md
+++ b/office-365-management-api/troubleshooting-the-office-365-management-activity-api.md
@@ -112,8 +112,9 @@ The most common category of questions come from customers using third-party prod
 ### Enabling unified audit logging in Office 365
 
 If you've just set up an app that's trying to use the Management Activity API and it's not working, be sure that you've enabled unified audit logging for your Office 365 organization. You do this by turning on the Office 365 audit log. For instructions, see [Turn Office 365 audit log search on or off](/microsoft-365/compliance/turn-audit-log-search-on-or-off).
+
 > [!NOTE]
-> The admin audit log configuration change can take up to 60 minutes to take effect.
+> The unified audit log configuration change can take up to 60 minutes to take effect.
 
 If unified auditing isn't enabled, you will typically receive an error that contains the following string: `Microsoft.Office.Compliance.Audit``.DataServiceException: Tenant <tenantID> does not exist.`
 

--- a/office-365-management-api/troubleshooting-the-office-365-management-activity-api.md
+++ b/office-365-management-api/troubleshooting-the-office-365-management-activity-api.md
@@ -112,6 +112,8 @@ The most common category of questions come from customers using third-party prod
 ### Enabling unified audit logging in Office 365
 
 If you've just set up an app that's trying to use the Management Activity API and it's not working, be sure that you've enabled unified audit logging for your Office 365 organization. You do this by turning on the Office 365 audit log. For instructions, see [Turn Office 365 audit log search on or off](/microsoft-365/compliance/turn-audit-log-search-on-or-off).
+> [!NOTE]
+> The admin audit log configuration change can take up to 60 minutes to take effect.
 
 If unified auditing isn't enabled, you will typically receive an error that contains the following string: `Microsoft.Office.Compliance.Audit``.DataServiceException: Tenant <tenantID> does not exist.`
 


### PR DESCRIPTION
Added a note that the Audit log is not ready right after it has been turned on. 
When you enable it, there is a note "WARNING: The admin audit log configuration change you specified could take up to 60 minutes to take effect." in PowerShell