### PR TITLE
Link 2 blogs to this article please

### DIFF
--- a/office-365-management-api/office-365-management-activity-api-reference.md
+++ b/office-365-management-api/office-365-management-activity-api-reference.md
@@ -634,5 +634,5 @@ When the service encounters an error, it will report the error response code to 
 |AF20053|Only one language may be present in the Accept-Language header.|
 |AF20054|Invalid syntax in Accept-Language header.|
 |AF429|Too many requests. Method={0}, PublisherId={1}<br/><br/>{0} = HTTP Method<br/><br/>{1} = Tenant GUID used as PublisherIdentifier</p></li></ul>|
-|AF50000|An internal error occurred. Retry the request.|
+|AF50000|An internal error occurred. Retry the request.| 
 


### PR DESCRIPTION
Mas Libman (PG) has asked me to link the 2 blogs we wrote late last year as a reference to this article. Similar to what we have here (https://learn.microsoft.com/en-us/microsoft-365/compliance/sensitivity-labels-office-apps?view=o365-worldwide#auditing-labeling-activities). those two blogs became very popular, and they are being referenced by PG in many conversations. I didn't want to place the reference awkwardly, so I think you are the best team to decide where in the doc to place it